### PR TITLE
[notesnook-appimage] Install the AppImage to /usr/bin.

### DIFF
--- a/notesnook-appimage/PKGBUILD
+++ b/notesnook-appimage/PKGBUILD
@@ -11,7 +11,7 @@ conflicts=("${pkgname%-appimage}")
 providers=("${pkgname%-appimage}")
 depends=('hicolor-icon-theme' 'zlib' 'glibc')
 options=(!strip)
-_install_path="/opt/appimages"
+_install_path="/usr/bin"
 source=("${pkgname%-appimage}-${pkgver}.AppImage::${_githuburl}/releases/download/v${pkgver}/${pkgname%-appimage}_linux_${arch}.AppImage")
 sha256sums=('27fb287afeb27fc72a866b96b357cd665d2c37e39c7cd439585c3fbb1bb5996b')
     
@@ -22,7 +22,7 @@ prepare() {
 }
     
 package() {
-    install -Dm755 "${srcdir}/${pkgname%-appimage}-${pkgver}.AppImage" "${pkgdir}/${_install_path}/${pkgname%-appimage}.AppImage"
+    install -Dm755 "${srcdir}/${pkgname%-appimage}-${pkgver}.AppImage" "${pkgdir}/${_install_path}/${pkgname%-appimage}"
     for _icons in 16x16 32x32 48x48 64x64 128x128 256x256 512x512 1024x1024;do
       install -Dm644 "${srcdir}/squashfs-root/usr/share/icons/hicolor/${_icons}/apps/${pkgname%-appimage}.png" \
       -t "${pkgdir}/usr/share/icons/hicolor/${_icons}/apps"


### PR DESCRIPTION
[upscayl-bin](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=upscayl-bin#n30) installs the AppImage to this path as well.