### PR TITLE
[hoptodesk-bin] Update PKGBUILD

### DIFF
--- a/hoptodesk-bin/PKGBUILD
+++ b/hoptodesk-bin/PKGBUILD
@@ -20,7 +20,7 @@ depends=(
 source=(
     "${pkgname%-bin}-${pkgver}.deb::${url}/${pkgname%-bin}.deb"
 )
-sha256sums=('256a7bc6ba5519d9aefc048c90dbab30b6787526503b7abac551f2066334c9ae')
+sha256sums=('6f04637c0b4426c365176385666cde27b089037ba4173f92065775a95d217f89')
 build() {
     bsdtar -xf "${srcdir}/data.tar.xz"
     sed "s|/usr/share/icons/hicolor/128x128/${pkgname%-bin}.png|${pkgname%-bin}|g" -i "${srcdir}/usr/share/applications/${pkgname%-bin}.desktop"


### PR DESCRIPTION
Fix invalid checksum of deb package version `1.4.5`.