### PR TITLE
[amethyst-player-bin] Fix url

### DIFF
--- a/amethyst-player-bin/PKGBUILD
+++ b/amethyst-player-bin/PKGBUILD
@@ -10,8 +10,7 @@ arch=(
     'aarch64'
     'x86_64'
 )
-url="https://amethyst.pages.dev/"
-_ghurl="https://github.com/Geoxor/Amethyst"
+url="https://github.com/Geoxor/Amethyst"
 license=('MIT')
 provides=("${pkgname%-bin}=${pkgver}")
 conflicts=("${pkgname%-bin}")

--- a/amethyst-player-bin/PKGBUILD
+++ b/amethyst-player-bin/PKGBUILD
@@ -11,6 +11,7 @@ arch=(
     'x86_64'
 )
 url="https://github.com/Geoxor/Amethyst"
+_ghurl="https://github.com/Geoxor/Amethyst"
 license=('MIT')
 provides=("${pkgname%-bin}=${pkgver}")
 conflicts=("${pkgname%-bin}")


### PR DESCRIPTION
Old url (https://amethyst.pages.dev/) is not working anymore and every other repository is using github link instead (https://github.com/Geoxor/amethyst)