### PR TITLE
Fix detecting Steam games by Steam Achievement Notifier

### DIFF
--- a/steamachievementnotifier-bin/PKGBUILD
+++ b/steamachievementnotifier-bin/PKGBUILD
@@ -65,14 +65,8 @@ prepare() {
         s/v${_mainver}//g
         s/\ (V${_mainver})//g
     " "${srcdir}/squashfs-root/${pkgname%-bin}v${_mainver}.desktop"
-    asar e "${srcdir}/squashfs-root/resources/app.asar" "${srcdir}/app.asar.unpacked"
-    rm -rf "${srcdir}/squashfs-root/resources/app.asar"
-    find "${srcdir}/app.asar.unpacked/dist" -type f -exec sed -i "s/process.resourcesPath/\'\/usr\/lib\/${pkgname%-bin}\'/g" {} \;
-    rm -rf "${srcdir}/app.asar.unpacked/node_modules/steamworks.js/_previous"
     rm -rf "${srcdir}/squashfs-root/resources/app.asar.unpacked/node_modules/steamworks.js/_previous"
-    rm -rf "${srcdir}/app.asar.unpacked/node_modules/steamworks.js/dist/win64"
     rm -rf "${srcdir}/squashfs-root/resources/app.asar.unpacked/node_modules/steamworks.js/dist/win64"
-    asar p "${srcdir}/app.asar.unpacked" "${srcdir}/squashfs-root/resources/app.asar"
     find "${srcdir}/squashfs-root" -type d -exec chmod 755 {} +
 }
 package() {


### PR DESCRIPTION
Steps to reproduce:
* Launch notifier
* Launch some Steam game
* Now popup should appear that detected Steam game
 
All that worked only when launching AppImage itself, but not on that package.
Anyway, all that in PR is enough to fix that.