### PR TITLE
fix(godot-launcher-bin): support reverse-DNS desktop filename

### DIFF
--- a/godot-launcher-bin/PKGBUILD
+++ b/godot-launcher-bin/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: zxp19821005 <zxp19821005 at 163 dot com>
 pkgname=godot-launcher-bin
 _pkgname='Godot Launcher'
+_desktopname='org.godotlauncher.launcher.desktop'
 pkgver=1.10.1
 _electronversion=41
 pkgrel=1
@@ -33,6 +34,11 @@ sha256sums_x86_64=('40e3f45c6dda5cc3956a3d31cfa5830895fc2fd7317f85233f919d0c4a6a
 _get_app_dir() {
     find "${srcdir}" -type f -name "resources.pak" -exec dirname {} + | head -n 1
 }
+_get_desktop_file() {
+    local _desktop_file="${srcdir}/usr/share/applications/${_desktopname}"
+    [[ -f "${_desktop_file}" ]] || _desktop_file="${srcdir}/usr/share/applications/${_pkgname}.desktop"
+    printf '%s\n' "${_desktop_file}"
+}
 _check_electron_version() {
     echo "Verifying Electron version..."
     local _main_exe=$(find "$(_get_app_dir)" -maxdepth 1 -type f -executable -printf '%s %p\n' | sort -nr | head -1 | cut -d' ' -f2-)
@@ -44,6 +50,8 @@ _check_electron_version() {
         echo -e "Electron version verified: \033[1;31m${_elec_ver}\033[0m"
 }
 prepare() {
+    local _desktop_file
+    _desktop_file="$(_get_desktop_file)"
     sed -i -e "
         s/@electronversion@/${_electronversion}/g
         s/@appname@/${pkgname%-bin}/g
@@ -54,11 +62,18 @@ prepare() {
     sed -i -e "
         s/\"\/opt\/${_pkgname}\/${_pkgname}\"/${pkgname%-bin}/g
         s/Icon=${_pkgname}/Icon=${pkgname%-bin}/g
-    " "${srcdir}/usr/share/applications/${_pkgname}.desktop"
+    " "${_desktop_file}"
     local _app_dir=$(_get_app_dir)
     find "${_app_dir}/resources" -type d -exec chmod 755 {} +
 }
 package() {
+    local _desktop_file
+    _desktop_file="$(_get_desktop_file)"
+    local _installed_desktop_file="${pkgname%-bin}.desktop"
+    if [[ "${_desktop_file##*/}" == "${_desktopname}" ]]; then
+        _installed_desktop_file="${_desktopname}"
+    fi
+
     install -Dm755 "${srcdir}/${pkgname%-bin}.sh" "${pkgdir}/usr/bin/${pkgname%-bin}"
     install -Dm755 -d "${pkgdir}/usr/lib/${pkgname%-bin}"
 	local _app_dir=$(_get_app_dir)
@@ -70,6 +85,6 @@ package() {
 		install -Dm644 "${_i}" "${pkgdir}${_target_dir}/${pkgname%-bin}.${_extension}"
 	done
     install -Dm644 "${srcdir}/usr/share/icons/hicolor/256x256/apps/${_pkgname}.png" "${pkgdir}/usr/share/pixmaps/${pkgname%-bin}.png"
-    install -Dm644 "${srcdir}/usr/share/applications/${_pkgname}.desktop" "${pkgdir}/usr/share/applications/${pkgname%-bin}.desktop"
+    install -Dm644 "${_desktop_file}" "${pkgdir}/usr/share/applications/${_installed_desktop_file}"
     install -Dm644 "${srcdir}/LICENSE-${pkgver}.txt" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
 }


### PR DESCRIPTION
## Summary

Support the reverse-DNS desktop entry filename introduced by Godot Launcher
1.11 while retaining compatibility with the filename shipped by 1.10.x.

Godot Launcher 1.11 changes the desktop entry filename from
`Godot Launcher.desktop` to
`org.godotlauncher.launcher.desktop`.

The existing PKGBUILD references `Godot Launcher.desktop` directly in both
`prepare()` and `package()`. As a result, packaging fails when using the new
RPM because the expected legacy file no longer exists.

## Solution

Add a small desktop-file resolver that:

- Prefers `org.godotlauncher.launcher.desktop` when present.
- Falls back to `Godot Launcher.desktop` for existing releases.
- Preserves the current installed filename for legacy packages.
- Installs the reverse-DNS filename unchanged for 1.11 and later.

This allows the change to land while 1.10.1 remains current and avoids another
PKGBUILD change when 1.11 is released.

## Maintainer note

If this PKGBUILD is generated from a private template or update script, please
apply the equivalent change there so it remains in place during future version
updates.