### PR TITLE
deepin-wine-welink: 更新至 7.53.7 并修复无法安装/运行

### DIFF
--- a/deepin-wine-welink/.SRCINFO
+++ b/deepin-wine-welink/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = deepin-wine-welink
+	pkgdesc = 华为云 WeLink 数字化办公平台（wine 封装，WoW64 运行）
+	pkgver = 7.53.7
+	pkgrel = 1
+	url = https://www.huaweicloud.com/product/welink.html
+	install = deepin-wine-welink.install
+	arch = x86_64
+	license = LicenseRef-proprietary
+	depends = deepin-wine8-stable
+	depends = 7zip
+	depends = hicolor-icon-theme
+	optdepends = noto-fonts-cjk: 中文字体（推荐）
+	optdepends = wqy-microhei: 中文字体
+	optdepends = wqy-zenhei: 中文字体
+	conflicts = welink
+	conflicts = huaweicloudmeeting
+	source = deepin-wine-welink_7.53.7spark2.deb::https://mirrors.sdu.edu.cn/spark-store-repository/store/chat/com.huaweicloud.welink.spark/com.huaweicloud.welink.spark_7.53.7spark2_i386.deb
+	source = deepin-wine-welink.sh
+	sha256sums = 4415488537b92e566d7d87ac1a80d6dddad73a0a820dbbfce18b01083496377b
+	sha256sums = SKIP
+
+pkgname = deepin-wine-welink

--- a/deepin-wine-welink/PKGBUILD
+++ b/deepin-wine-welink/PKGBUILD
@@ -2,72 +2,65 @@
 _pkgname=welink
 pkgname="deepin-wine-${_pkgname}"
 _sparkname="com.huaweicloud.${_pkgname}.spark"
-_appname=WeLink
-pkgver=7.37.3
-_sparkver=7.21.3.403spark1
-pkgrel=2
-pkgdesc="华为数字化办公实践,服务政企、高校等主要客户,是全场景安全、智能、的数字化办公平台,帮助AnyBody、AnyWhere、AnyDevice、doAnyBusiness4A办公。"
-arch=("x86_64")
+pkgver=7.53.7
+_sparkver="${pkgver}spark2"
+pkgrel=1
+pkgdesc="华为云 WeLink 数字化办公平台（wine 封装，WoW64 运行）"
+arch=('x86_64')
 url="https://www.huaweicloud.com/product/welink.html"
-license=('LicenseRef-custom')
+license=('LicenseRef-proprietary')
 depends=(
-    'deepin-wine6-stable'
-    'spark-dwine-helper'
-    'xdg-utils'
-)
-makededpends=(
-    'p7zip'
+    'deepin-wine8-stable'
+    '7zip'
+    'hicolor-icon-theme'
 )
 optdepends=(
-    'wqy-microhei'
-    'wqy-zenhei'
+    'noto-fonts-cjk: 中文字体（推荐）'
+    'wqy-microhei: 中文字体'
+    'wqy-zenhei: 中文字体'
 )
-conflicts=(
-    "${_pkgname}"
-    "huaweicloudmeeting"
-)
+conflicts=("${_pkgname}" 'huaweicloudmeeting')
 install="${pkgname}.install"
 source=(
-    "${pkgname}_${_sparkver}.deb::https://mirrors.sdu.edu.cn/spark-store-repository/store//chat/${_sparkname}/${_sparkname}_${_sparkver}_i386.deb"
-    "${_appname}-${pkgver}.exe::https://welink.huaweicloud.com/download/${_appname}_setup.exe"
-    #"fake_simsun.ttc::https://images.xuthus.cc/images/fake_simsun.ttc"
-    "LICENSE.html::https://www.huaweicloud.com/declaration/sa_cua_computing.html"
+    "${pkgname}_${_sparkver}.deb::https://mirrors.sdu.edu.cn/spark-store-repository/store/chat/${_sparkname}/${_sparkname}_${_sparkver}_i386.deb"
     "${pkgname}.sh"
 )
-sha256sums=('2a5046177ad2f57ebeff4176ffe4ae2717eed19c8fd2e84fad5b9f44305d16d1'
-            '045c334577032f51d963188d30254a0e1d8fea7876fbd7b00e78bd5b7bb59685'
-            'd5d83468ded64766fdfdb7e0e5b0510fcaa3c3102bcd01d57ac213d2b9d09e1b'
-            '457847c22fc306279a20070ee7578403653e5c2ed8c602065f5996cf353c4722')
-build() {
-    sed -e "s|@appname@|${_appname}|g" \
-        -e "s|@pkgname@|${pkgname}|g" \
-        -e "s|@sparkver@|${_sparkver%spark1}|g" \
-        -e "s|@appver@|${pkgver}|g" \
-        -i "${srcdir}/${pkgname}.sh"
-    bsdtar -xf "${srcdir}/data.tar.xz"
-    mv "${srcdir}/opt/apps/${_sparkname}" "${srcdir}/opt/apps/${pkgname}"
-    mkdir -p "${srcdir}/tmp"
-    msg "Extracting Deepin Wine ${_appname} archive ..."
-    7z x -aoa "${srcdir}/opt/apps/${pkgname}/files/files.7z" -o"${srcdir}/tmp"     
-    msg "Copying latest ${_appname} installer to ${srcdir}/tmp/drive_c/Program Files/${_appname} ..."
-    rm -rf "${srcdir}/tmp/drive_c/Program Files/${_appname}/" "${srcdir}/tmp/drive_c/Program Files (x86)"
-    mkdir -p "${srcdir}/tmp/drive_c/Program Files/${_appname}/"
-    install -m644 "${srcdir}/${_appname}-${pkgver}.exe" "${srcdir}/tmp/drive_c/Program Files/${_appname}/${_appname}-${pkgver}.exe"
-    #cp "${srcdir}/fake_simsun.ttc" "${srcdir}/tmp/drive_c/windows/Fonts/"
-    msg "Repackaging app archive ..."
-    rm -r "${srcdir}/opt/apps/${pkgname}/files/files.7z"
-    7z a -t7z -r "${srcdir}/opt/apps/${pkgname}/files/files.7z" "${srcdir}/tmp/*"
-    sed -e "s|chat|Network|g" \
-        -e "s|/opt/apps/${_sparkname}/entries/icons/hicolor/scalable/apps/${_sparkname}.png|${pkgname}|g" \
-        -e "s|\"/opt/apps/${_sparkname}/files/run.sh\"|${pkgname}|g" \
-        -i "${srcdir}/opt/apps/${pkgname}/entries/applications/${_sparkname}.desktop"
-    rm -rf "${srcdir}/opt/apps/${pkgname}/info"
-}
+sha256sums=('4415488537b92e566d7d87ac1a80d6dddad73a0a820dbbfce18b01083496377b'
+            'SKIP')
+
 package() {
-    cp -r "${srcdir}/opt" "${pkgdir}"
-    md5sum "${pkgdir}/opt/apps/${pkgname}/files/files.7z" | awk '{ print $1 }' > "${pkgdir}/opt/apps/${pkgname}/files/files.md5sum"
-    install -Dm644 "${srcdir}/opt/apps/${pkgname}/entries/applications/${_sparkname}.desktop" "${pkgdir}/usr/share/applications/${pkgname}.desktop"
-    install -Dm644 "${srcdir}/opt/apps/${pkgname}/entries/icons/hicolor/scalable/apps/${_sparkname}.png" "${pkgdir}/usr/share/pixmaps/${pkgname}.png"
+    bsdtar -xf "${srcdir}/data.tar.xz" -C "${srcdir}"
+
+    # 只安装 WeLink 应用归档（files.7z / md5sum），启动器在首次运行时
+    # 解出到用户的 win64 容器，避免把 32 位 windows 系统树带进包
+    install -Dm644 "${srcdir}/opt/apps/${_sparkname}/files/files.7z" \
+        "${pkgdir}/opt/apps/${_sparkname}/files/files.7z"
+    md5sum "${pkgdir}/opt/apps/${_sparkname}/files/files.7z" | awk '{print $1}' \
+        > "${srcdir}/files.md5sum"
+    install -Dm644 "${srcdir}/files.md5sum" \
+        "${pkgdir}/opt/apps/${_sparkname}/files/files.md5sum"
+
     install -Dm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
-    install -Dm644 "${srcdir}/LICENSE.html" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+
+    # 桌面项与图标
+    install -Dm644 /dev/stdin "${pkgdir}/usr/share/applications/${pkgname}.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=WeLink
+Name[zh_CN]=华为云 WeLink
+Comment=Huawei Cloud digital workplace
+Comment[zh_CN]=华为云数字化办公平台
+Exec=${pkgname}
+Icon=${pkgname}
+Terminal=false
+Categories=Network;InstantMessaging;
+StartupNotify=false
+EOF
+
+    local _s
+    for _s in 32x32 48x48 64x64 96x96 128x128 256x256; do
+        install -Dm644 \
+            "${srcdir}/opt/apps/${_sparkname}/entries/icons/hicolor/${_s}/apps/6EBA_WeLink.0.png" \
+            "${pkgdir}/usr/share/icons/hicolor/${_s}/apps/${pkgname}.png"
+    done
 }

--- a/deepin-wine-welink/deepin-wine-welink.install
+++ b/deepin-wine-welink/deepin-wine-welink.install
@@ -1,16 +1,14 @@
-info() {
-    echo -e "\033[0;34m============================提示/INFO==============================="
-    echo -e "此脚本主要是覆盖安装时使用，删除原有的运行及配置文件。"
-    echo -e "====================================================================\033[0m"
-}
 post_install() {
-    info
+    echo "首次启动 deepin-wine-welink 会创建 win64 wine 容器并部署 WeLink"
+    echo "到 ~/.deepinwine/Spark-Welink/，需要一些时间。"
+    echo "升级本包后首次启动会自动重新部署。"
+    echo "若聊天时需要中文输入，用 WELINK_IM=1 deepin-wine-welink 启动。"
 }
+
 post_upgrade() {
-    find /home -maxdepth 2 -name ".deepinwine" -exec rm -f \{\}/Deepin-WeLink/reinstalled \;
-    info
+    post_install
 }
-pre_remove() {
-    echo "deleting the WeLink bottle..."
-    find /home -maxdepth 2 -name ".deepinwine" -exec rm -rf \{\}/Deepin-WeLink/ \;
+
+post_remove() {
+    echo "各用户的 wine 容器保留在 ~/.deepinwine/Spark-Welink/，如不再需要请手动删除。"
 }

--- a/deepin-wine-welink/deepin-wine-welink.sh
+++ b/deepin-wine-welink/deepin-wine-welink.sh
@@ -1,95 +1,48 @@
 #!/bin/sh
+# 自包含 WoW64 启动器：新版 WeLink（7.53.x）的内置 exe 为 32 位，
+# 上游 spark deb 面向 spark-wine。Arch 上无 spark-wine，且经典 32 位的
+# deepin-wine6 已因上游源失效 + multilib 移除 lib32 依赖而难以安装。
+# deepin-wine8-stable 是 new-WoW64，无法驱动经典 win32 容器，但可用
+# win64 容器通过 WoW64 运行 32 位 WeLink.exe。故此处自建 win64 容器，
+# 只解出 WeLink 应用本体（不覆盖容器的 windows 系统树）。
 set -e
-BOTTLENAME="Deepin-@appname@"
-APPVER=@sparkver@
-WELINK_INSTALLER="@appname@"
-WELINK_VER=@appver@
-WELINK_INSTALLER_PATH="c:/Program Files/@appname@/${WELINK_INSTALLER}-${WELINK_VER}.exe"
-WINEPREFIX="$HOME/.deepinwine/${BOTTLENAME}"
-EXEC_PATH="c:/Program Files/${WELINK_INSTALLER}/${WELINK_INSTALLER}.exe"
-EXEC_FILE="${WINEPREFIX}/drive_c/Program Files/${WELINK_INSTALLER}/${WELINK_INSTALLER}.exe"
-START_SHELL_PATH="/opt/deepinwine/tools/run_v4.sh"
-export MIME_TYPE=""
-export DEB_PACKAGE_NAME=@pkgname@
-export APPRUN_CMD="deepin-wine6-stable"
-DISABLE_ATTACH_FILE_DIALOG=""
-EXPORT_ENVS=""
-SPECIFY_SHELL_DIR=$(dirname ${START_SHELL_PATH})
-export SPECIFY_SHELL_DIR
-ARCHIVE_FILE_DIR="/opt/apps/${DEB_PACKAGE_NAME}/files"
-export WINEDLLPATH=/opt/${APPRUN_CMD}/lib:/opt/${APPRUN_CMD}/lib64
-export LD_LIBRARY_PATH=/opt/apps/${DEB_PACKAGE_NAME}/files/lib32
-export WINEPREDLL="${ARCHIVE_FILE_DIR}/dlls"
-msg() {
-    ECHO_LEVEL=("\033[1;32m==> " "\033[1;31m==> ERROR: ")
-    echo -e "${ECHO_LEVEL[$1]}\033[1;37m$2\033[0m"
-}
-OpenWinecfg() {
-    msg 0 "Launching winecfg with ${APPRUN_CMD} in ${WINEPREFIX} ..."
-    env WINEPREFIX="${WINEPREFIX}" ${APPRUN_CMD} winecfg
-}
-DeployApp() {
-    # deploy bottle
-    msg 0 "Deploying ${WINEPREFIX} ..."
-    rm -rf "${WINEPREFIX}"
-    # run installer
-    msg 0 "Launching ${WELINK_INSTALLER_PATH} ..."
-    env WINEDLLOVERRIDES="winemenubuilder.exe=d" "${START_SHELL_PATH}" "${BOTTLENAME} ${APPVER}" "${WELINK_INSTALLER_PATH}" "$@"
 
-    touch "${WINEPREFIX}"/reinstalled
-    msg 0 "Creating ${WINEPREFIX}/PACKAGE_VERSION ..."
-    cat "/opt/apps/${DEB_PACKAGE_NAME}/files/files.md5sum" >"${WINEPREFIX}"/PACKAGE_VERSION
+APPRUN="deepin-wine8-stable"
+PKG="com.huaweicloud.welink.spark"
+FILES="/opt/apps/${PKG}/files"
+
+export WINEPREFIX="${HOME}/.deepinwine/Spark-Welink"
+export WINEARCH="win64"
+export WINEDLLOVERRIDES="mscoree=,mshtml="
+export WINEDEBUG="${WINEDEBUG:-fixme-all}"
+# CEF/Electron 应用在 wine 下常因输入法桥接异常导致输入框无响应；
+# 允许用户用 WELINK_IM=1 保留输入法（中文输入），默认关闭以保证登录可输入。
+[ -z "${WELINK_IM}" ] && export XMODIFIERS="@im=none"
+
+VER_FILE="${WINEPREFIX}/.welink_version"
+CUR_VER="$(cat "${FILES}/files.md5sum" 2>/dev/null || echo unknown)"
+
+deploy() {
+    echo "==> 正在部署 WeLink 到 ${WINEPREFIX}（首次或升级，需要一些时间）..."
+    rm -rf "${WINEPREFIX}"
+    "${APPRUN}" wineboot -u >/dev/null 2>&1
+    7z x -aoa "${FILES}/files.7z" "drive_c/Program Files/WeLink/*" -o"${WINEPREFIX}" >/dev/null
+    printf '%s' "${CUR_VER}" > "${VER_FILE}"
+    echo "==> 部署完成。"
 }
-WakeApp() {
-    env WINEPREDLL="${ARCHIVE_FILE_DIR}/dlls" \
-        WINEDLLPATH="/opt/${APPRUN_CMD}/lib:/opt/${APPRUN_CMD}/lib64" \
-        WINEPREFIX="${WINEPREFIX}" "${APPRUN_CMD}" /opt/deepinwine/tools/sendkeys.exe w
-}
-Run() {
-    if [ -z "${DISABLE_ATTACH_FILE_DIALOG}" ]; then
-        export ATTACH_FILE_DIALOG=1
-    fi
-    if [ -n "${EXPORT_ENVS}" ]; then
-        export "${EXPORT_ENVS}"
-    fi
-    if [ -n "${EXEC_PATH}" ]; then
-        if [ ! -f "${WINEPREFIX}/reinstalled" ] || [ ! -f "${EXEC_FILE}" ]; then
-            DeployApp "$@"
-            exit 0
-        fi
-        if [ -z "${EXEC_PATH##*.lnk*}" ]; then
-            msg 0 "Launching  ${EXEC_PATH} lnk file ..."
-            exec "${START_SHELL_PATH}" "${BOTTLENAME} ${APPVER}" "C:/windows/command/start.exe" "/Unix" "${EXEC_PATH}" "$@" || exit $?
-        else
-            msg 0 "Launching  ${EXEC_PATH} ..."
-            exec "${START_SHELL_PATH}" "${BOTTLENAME}" "${APPVER}" "${EXEC_PATH}" "$@" || exit $?
-        fi
-    else
-        exec "${START_SHELL_PATH}" "${BOTTLENAME}" "${APPVER}" "uninstaller.exe" "$@" || exit $?
-    fi
-}
-HelpApp() {
-    echo " Extra Commands:"
-    echo " winecfg          Open winecfg"
-    echo " -w/--wake       Wake up background program"
-    echo " -h/--help        Show program help info"
-}
-if [ -z "$1" ]; then
-    Run "$@"
-    exit 0
-fi
-case $1 in
-"winecfg")
-    OpenWinecfg
-    ;;
-"-w" | "--wake")
-    WakeApp "$@"
-    ;;
-"-h" | "--help")
-    HelpApp "$@"
-    ;;
-*)
-    Run "$@"
-    ;;
+
+case "$1" in
+    -r|--redeploy) rm -f "${VER_FILE}"; shift ;;
+    -h|--help)
+        echo "用法: deepin-wine-welink [-r|--redeploy] [-h|--help]"
+        echo "  -r  强制重新部署 wine 容器"
+        echo "  环境变量 WELINK_IM=1 可保留输入法（中文输入）"
+        exit 0 ;;
 esac
-exit 0
+
+if [ ! -f "${VER_FILE}" ] || [ "$(cat "${VER_FILE}")" != "${CUR_VER}" ]; then
+    deploy
+fi
+
+exec "${APPRUN}" explorer /desktop=WeLink,1280x800 \
+    "C:/Program Files/WeLink/WeLink.exe" --no-sandbox --disable-gpu "$@"


### PR DESCRIPTION
## 背景
`deepin-wine-welink` 当前无法安装/运行，已在 AUR flag out-of-date（2026-08-31）。

## 问题
1. **源全失效**：官网 `WeLink_setup.exe`、旧版 spark deb、动态 LICENSE 页均 404 或校验和漂移。
2. **底座架构变化**：新版内置 `WeLink.exe` 为 32 位，上游 deb 依赖 `spark-wine`（Arch 无此包）。
   - 经典 32 位 `deepin-wine6-stable`：上游 deb 源现 403，且 multilib 已移除其 `lib32-libcap/pam/openal/libpcap...` 依赖，难以安装。
   - `deepin-wine8-stable`：new-WoW64 构建（缺 `i386-unix`），无法驱动经典 win32 容器，会报 `32-bit installation, it cannot support 64-bit applications`。

## 方案
改为**自包含 WoW64**：`deepin-wine8-stable` 建 **win64** 容器，仅解出 WeLink 应用本体（不覆盖 32 位 windows 系统树），经 WoW64 运行 32 位 exe。

- 单一版本化源：Spark 商店 `7.53.7spark2` deb
- 依赖精简：`deepin-wine8-stable` + `7zip` + `hicolor-icon-theme`
- 移除废弃的 `spark_run_v4` 集成与旧启动脚本
- 新增自包含启动器（首次/升级自动部署，md5 版本校验）

## 验证
本机（Arch Linux）已构建安装，WeLink 正常启动、登录界面出现，可扫码登录。

> 注：CEF 文字输入框在 wine 下仍有已知焦点限制，登录建议扫码；`WELINK_IM=1` 可保留输入法。