### PR TITLE
orca-ide-bin: add asar to makedepends

### DIFF
--- a/orca-ide-bin/.SRCINFO
+++ b/orca-ide-bin/.SRCINFO
@@ -6,6 +6,7 @@ pkgbase = orca-ide-bin
 	arch = aarch64
 	arch = x86_64
 	license = MIT
+	makedepends = asar
 	depends = electron43
 	depends = nodejs
 	depends = python

--- a/orca-ide-bin/PKGBUILD
+++ b/orca-ide-bin/PKGBUILD
@@ -22,6 +22,9 @@ depends=(
     'github-cli'
     'npm'
 )
+makedepends=(
+    'asar'
+)
 options=(
     '!emptydirs'
 )


### PR DESCRIPTION
Thanks for packaging Orca so quickly.

`orca-ide-bin` 1.4.192-1 fails to build on a clean system because `prepare()` uses `asar` but the package declares no `makedepends`:

```
==> Starting prepare()...
Verifying Electron version...
Electron version verified: 43
/home/sem/.cache/yay/orca-ide-bin/PKGBUILD: line 64: asar: command not found
==> ERROR: A failure occurred in prepare().
    Aborting...
```

`asar` is called three times — `asar e` at line 64, `asar p` at line 70, and referenced again at 72 — so the build cannot succeed unless the user happens to already have it installed.

`asar` is in `extra`, so this just needs declaring. Installing `extra/asar 4.3.0-1` and rebuilding succeeds with no other changes; `orca-ide-bin 1.4.192-1` then builds and installs cleanly.

This PR adds the `makedepends=('asar')` block to `PKGBUILD` and the matching `makedepends = asar` line to `.SRCINFO` (placed in canonical `--printsrcinfo` field order, between `license` and `depends`).

**Tested on:** Arch Linux, x86_64, `electron43` 43.4.1-1, `asar` 4.3.0-1.